### PR TITLE
Add Dockerfile for building a custom ODR image.

### DIFF
--- a/Dockerfile-odr
+++ b/Dockerfile-odr
@@ -1,0 +1,8 @@
+# TODO: Use Waypoint to build this image, and template the base image
+# and tag for Nomad Pack
+FROM hashicorp/nomad-pack:0.0.1-techpreview.3 AS builder
+
+FROM hashicorp/waypoint-odr:latest
+
+COPY --from=builder /bin/nomad-pack /usr/local/bin/nomad-pack
+


### PR DESCRIPTION
The Dockerfile added in this PR can be used to add the Nomad Pack binary, from Nomad Pack tech preview version 3, to a custom Waypoint ODR image.

Future plans for this Dockerfile include automatically building and pushing this to a registry using Waypoint in CI, and templating the base image.