### PR TITLE
Fix multiple issues in the ODR Dockerfile

### DIFF
--- a/Dockerfile-odr
+++ b/Dockerfile-odr
@@ -14,10 +14,12 @@ COPY . /go/plugin
 
 # Build the plugin
 RUN chmod +x ./print_arch
-RUN make all
+RUN protoc -I thirdparty/proto -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./platform/output.proto \
+    && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /go/plugin/bin/waypoint-plugin-nomad-pack /go/plugin/main.go
 
-# Create the zipped binaries
-RUN make zip
+FROM alpine:latest AS git
+
+RUN apk add git
 
 # TODO: Use Waypoint to build this image, and template the base image
 # and tag for Nomad Pack
@@ -25,6 +27,6 @@ FROM hashicorp/nomad-pack:0.0.1-techpreview.3 AS builder
 
 FROM hashicorp/waypoint-odr:latest
 
-COPY --from=builder /bin/nomad-pack /usr/local/bin/nomad-pack
-COPY --from=build /go/plugin/bin/*.zip $HOME/.config/waypoint/plugins/waypoint-plugin-nomad-pack
-
+COPY --from=git /usr/bin/git /kaniko/git
+COPY --from=builder /bin/nomad-pack /kaniko/nomad-pack
+COPY --from=build /go/plugin/bin/waypoint-plugin-nomad-pack /root/.config/waypoint/plugins/waypoint-plugin-nomad-pack

--- a/Dockerfile-odr
+++ b/Dockerfile-odr
@@ -17,16 +17,14 @@ RUN chmod +x ./print_arch
 RUN protoc -I thirdparty/proto -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./platform/output.proto \
     && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /go/plugin/bin/waypoint-plugin-nomad-pack /go/plugin/main.go
 
-FROM alpine:latest AS git
-
-RUN apk add git
-
 # TODO: Use Waypoint to build this image, and template the base image
 # and tag for Nomad Pack
 FROM hashicorp/nomad-pack:0.0.1-techpreview.3 AS builder
 
-FROM hashicorp/waypoint-odr:latest
+FROM paladindevops/waypoint-odr-alpine:latest
 
-COPY --from=git /usr/bin/git /kaniko/git
+# Git CLI is required for Nomad Pack
+RUN apk add --no-cache git
+
 COPY --from=builder /bin/nomad-pack /kaniko/nomad-pack
 COPY --from=build /go/plugin/bin/waypoint-plugin-nomad-pack /root/.config/waypoint/plugins/waypoint-plugin-nomad-pack

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ build-docker:
 # Build the plugin into the Waypoint ODR image
 build-docker-odr:
 	rm -rf ./releases
-	DOCKER_BUILDKIT=1 docker build --output releases --progress=plain -f=Dockerfile-odr .
+	DOCKER_BUILDKIT=1 docker build --progress=plain -f=Dockerfile-odr .

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ using remote operations, they may be set via `waypoint config set -runner`, as d
 
 ### Remote Operations
 
-The Waypoint ODR image has been extended, and a custom ODR image which includes the 
-Nomad Pack binary is available at the [Docker repository `paladindevops/waypoint-odr-nomad-pack:latest`](https://hub.docker.com/r/paladindevops/waypoint-odr-nomad-pack). With the Waypoint CLI, you can use this image
+The Waypoint ODR image has been customized and extended, and a custom ODR image 
+which includes the Nomad Pack binary is available at the [Docker repository `paladindevops/waypoint-odr-nomad-pack:latest`](https://hub.docker.com/r/paladindevops/waypoint-odr-nomad-pack). With the Waypoint CLI, you can use this image
 in your project's remote operations by creating a runner profile with this image configured!
 An example of this for a Docker ODR is below, but this can work on any platform for which
 there is a task launcher plugin.

--- a/platform/deploy.go
+++ b/platform/deploy.go
@@ -139,6 +139,7 @@ func (p *Platform) generation(
 	statusCmd := exec.Command("nomad-pack", statusArgs...)
 	output, err := statusCmd.Output()
 	if err != nil {
+		ui.Output(string(output[:]), terminal.WithErrorStyle())
 		ui.Output("Error getting pack status: %s", err, terminal.WithErrorStyle())
 		return nil, err
 	}
@@ -267,6 +268,7 @@ func (p *Platform) packStatus(
 	statusCmd := exec.Command("nomad-pack", statusArgs...)
 	output, err := statusCmd.Output()
 	if err != nil {
+		ui.Output(string(output[:]), terminal.WithErrorStyle())
 		ui.Output("Error getting pack status: %s", err, terminal.WithErrorStyle())
 		return err
 	}


### PR DESCRIPTION
1. The Nomad Pack binary is now installed at /kaniko/nomad-pack.
2. The plugin binary is no longer copied from a zipped file. The raw binary is copied from the builder image.
3. The build step runs with CGO disabled. Prior to this, the plugin binary was not executable on the ODR image - "not found" was returned, and it was therefore not usable.
4. Build only the linux_amd64 flavor of the plugin binary during the ODR Docker build to reduce build time.
5. Lastly, copy the Git CLI after installing to a plain alpine image. apk is not available for use in the ODR image, so we steal it this way.

This PR will remain in draft for now. The current issue I'm facing is below:
```shell
$ waypoint deploy

» Deploying hello-world-pack...
  Performing operation on "docker" with runner profile "docker-nomad-pack"

» Cloning data from Git
  URL: https://github.com/paladin-devops/waypoint-plugin-nomad-pack
  Ref: main

» Downloading from Git
  Git Commit: 5d455f286d72736f5691ab33ace023c3829dd0b2
   Timestamp: 2022-10-20 01:12:45 +0000 UTC
     Message: build: Update ODR Dockerfile to build the plugin from source, add Makefile target.
  
  Prior to this commit, the plugin itself wasn't being added to the ODR image. This fixes that, and adds a Makefile target, build-docker-odr, for building the ODR image.
  
! debug: %!!(MISSING)!(MISSING)!(MISSING)s(MISSING)
  go-getter URL is github.com/hashicorp/nomad-pack-community-registry
  ! Could Not Install Registry
  !   Error: error downloading 'https://github.com/hashicorp/nomad-pack-community-registry.git': error running /kaniko/git: 
  !   Context:
  !          Cache Path: /root/.cache/nomad/packs
  !     Registry Source: github.com/hashicorp/nomad-pack-community-registry
  !       Registry Name: default
  !                 Ref: 
  !           Pack Name: 
  ! Error Parsing Args Or Flags
  !   Error: error downloading 'https://github.com/hashicorp/nomad-pack-community-registry.git': error running /kaniko/git: 
  !   Context:
  
! Error adding pack registry: exit status 1
! exit status 1

```